### PR TITLE
adding version lister and overrider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ You need node 6, babel-node should also work with lower versions.
 
 If for some reason future version of henkaku change the way its patched, you add `--use-python-build`
 to your command to run the embedded `build.sh` file, if you do, you need python3 installed.
+
+Install a specific version
+==========================
+you can see which version are available with `node index --list-release`
+if you want for example install the version:
+```
+Version v1.1 (2016-08-10):
+* **Dynarec support**: ...
+```
+you need to run `node index --tag v1.1` or, if reinstalling, `node index --reinstall --tag v1.1`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localkaku",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "local version of hankaku",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
list version with --list-release, eg:

```
localkaku $ node index --list-release
====================

Version v1.4 (2016-09-06):
This update improves the quality of the system performance.

* Changed how PSN spoofing is done. This should fix problems a minority of users experience regarding game saves.
* Removed update blocking features as a side effect of above.
* Update to [VitaShell 0.91](https://github.com/TheOfficialFloW/VitaShell/releases/tag/0.91). This is the last VitaShell update bundled into HENkaku. Please use VitaShell's built in network update feature to update VitaShell as a standalone component.
====================

====================

Version v1.3 (2016-08-31):
* Fixed issue where YouTube did not work
* Added support for PSTV and Vita Slim internal storage
* Updated to [VitaShell 0.86](https://github.com/TheOfficialFloW/VitaShell/releases/tag/0.86)
====================

====================

Version v1.2 (2016-08-28):
http://yifan.lu/2016/08/27/henkaku-update/

  * **PSN spoofing**: You can access PSN without updating to 3.61! Please continue reading for some important notes.
  * Safe homebrew support: Developers can optionally mark their homebrews as "safe" and it will _not_ gain restricted API access. We highly recommend developers who are not using such features to update their packages as safe.
  * [VitaShell 0.8](https://github.com/TheOfficialFloW/VitaShell): Read the release notes from The_FloW for the list of changes to VitaShell.
  * Version string: A callback to the PSP days where every hack would change the system version string. We do that too now (see the screenshot) so we can provide better support to our users.
====================

====================

Version v1.1 (2016-08-10):
  * **Dynarec support**: Developers can generate ARM code and execute it directly. This aids in JIT engines for emulators.
  * [Offline installer](https://github.com/henkaku/offline-installer/releases): HENkaku can now run without a network connection thanks to work by xyz. He also made a nice [writeup](https://blog.xyz.is/2016/henkaku-offline-installer.html) that you should check out if you're interested in the technical details.
  * [VitaShell 0.7](https://bitbucket.org/TheOfficialFloW/vitashell/): When we originally released HENkaku, we forked VitaShell to molecularShell because we didn't want to spend too much time writing our own file manager. Thanks to The_FloW, our changes have been merged to the official VitaShell codebase and we no longer need molecularShell. This release had added many new features and bug fixes to the shell.
====================

====================

Version v1.0 (2016-08-06):
Download the source and follow the directions for building and hosting.
====================


```

and install a specific version with `--tag ${tag}`
